### PR TITLE
FEC-10253 Fixed 'ApplicationName' sent to the DMSConfiguration request

### DIFF
--- a/Sources/OTT/KalturaOTTPlayerManager.swift
+++ b/Sources/OTT/KalturaOTTPlayerManager.swift
@@ -54,7 +54,7 @@ class KalturaOTTPlayerManager: KalturaPlayerManager {
         
         request.set(method: .get)
         
-        let ApplicationName = "com.kaltura.player"
+        let ApplicationName = "com.kaltura.player." + String(partnerId)
         let ClientVersion = "4"
         let Platform = "iOS"
         let Tag = "1"


### PR DESCRIPTION
Fixed 'ApplicationName' sent to the DMSConfiguration request, it needs to be unique per customer.

Solves FEC-10253