### PR TITLE
FEC-10671 The Provider Server error is not exposed correctly

### DIFF
--- a/KalturaPlayer.podspec
+++ b/KalturaPlayer.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |sp|
     sp.source_files = 'Sources/*', 'Sources/Basic/*'
     
-    sp.dependency 'PlayKit', '~> 3.18'
+    sp.dependency 'PlayKit', '~> 3.19'
     
   end
   
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     sp.resources = 'Sources/OTT/*.xcdatamodeld'
     
     sp.dependency 'KalturaPlayer/Core'
-    sp.dependency 'PlayKitProviders', '~> 1.9'
+    sp.dependency 'PlayKitProviders', '~> 1.10'
     sp.dependency 'PlayKitKava', '~> 1.6'
   end
 
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
     sp.resources = 'Sources/OVP/*.xcdatamodeld'
     
     sp.dependency 'KalturaPlayer/Core'
-    sp.dependency 'PlayKitProviders', '~> 1.9'
+    sp.dependency 'PlayKitProviders', '~> 1.10'
     sp.dependency 'PlayKitKava', '~> 1.6'
   end
   

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -131,7 +131,7 @@ import PlayKitKava
             * callback:
             * error: A `KalturaPlayerError` in case of an issue. See `KalturaPlayerError` for more details.
      */
-    @objc public func loadMedia(options: OTTMediaOptions, callback: @escaping (_ error: Error?) -> Void) {
+    @objc public func loadMedia(options: OTTMediaOptions, callback: @escaping (_ error: NSError?) -> Void) {
         ottMediaOptions = options
         
         if options.ks?.isEmpty == false {
@@ -151,7 +151,7 @@ import PlayKitKava
                 if let error = error {
                     switch error {
                     case let pkError as PKError:
-                        callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription))
+                        callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription).asNSError)
                     case let nsError as NSError:
                         var code = String(nsError.code)
                         if let serverErrorCode = nsError.userInfo[ProviderServerErrorCodeKey] as? String, !serverErrorCode.isEmpty {
@@ -161,12 +161,12 @@ import PlayKitKava
                         if let serverErrorMessage = nsError.userInfo[ProviderServerErrorMessageKey] as? String, !serverErrorMessage.isEmpty {
                             message = serverErrorMessage
                         }
-                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message))
+                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message).asNSError)
                     default:
-                        callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription))
+                        callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription).asNSError)
                     }
                 } else {
-                    callback(KalturaPlayerError.invalidPKMediaEntry)
+                    callback(KalturaPlayerError.invalidPKMediaEntry.asNSError)
                 }
                 
                 return
@@ -174,7 +174,7 @@ import PlayKitKava
             
             // The DMS Configuration is needed in order to continue.
             guard let ovpPartnerId = KalturaOTTPlayerManager.shared.cachedConfigData?.ovpPartnerId else {
-                callback(KalturaPlayerError.configurationMissing)
+                callback(KalturaPlayerError.configurationMissing.asNSError)
                 return
             }
             

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -150,10 +150,18 @@ import PlayKitKava
             guard let mediaEntry = pkMediaEntry else {
                 if let error = error {
                     switch error {
-                    case let nsError as NSError:
-                        callback(KalturaPlayerError.mediaProviderError(code: String(nsError.code), message: nsError.description))
                     case let pkError as PKError:
                         callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription))
+                    case let nsError as NSError:
+                        var code = String(nsError.code)
+                        if let serverErrorCode = nsError.userInfo[ProviderServerErrorCodeKey] as? String, !serverErrorCode.isEmpty {
+                            code = serverErrorCode
+                        }
+                        var message = nsError.description
+                        if let serverErrorMessage = nsError.userInfo[ProviderServerErrorMessageKey] as? String, !serverErrorMessage.isEmpty {
+                            message = serverErrorMessage
+                        }
+                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message))
                     default:
                         callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription))
                     }

--- a/Sources/OVP/KalturaOVPPlayer.swift
+++ b/Sources/OVP/KalturaOVPPlayer.swift
@@ -127,10 +127,18 @@ import PlayKitProviders
             guard let mediaEntry = pkMediaEntry else {
                 if let error = error {
                     switch error {
-                    case let nsError as NSError:
-                        callback(KalturaPlayerError.mediaProviderError(code: String(nsError.code), message: nsError.description))
                     case let pkError as PKError:
                         callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription))
+                    case let nsError as NSError:
+                        var code = String(nsError.code)
+                        if let serverErrorCode = nsError.userInfo[ProviderServerErrorCodeKey] as? String, !serverErrorCode.isEmpty {
+                            code = serverErrorCode
+                        }
+                        var message = nsError.description
+                        if let serverErrorMessage = nsError.userInfo[ProviderServerErrorMessageKey] as? String, !serverErrorMessage.isEmpty {
+                            message = serverErrorMessage
+                        }
+                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message))
                     default:
                         callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription))
                     }

--- a/Sources/OVP/KalturaOVPPlayer.swift
+++ b/Sources/OVP/KalturaOVPPlayer.swift
@@ -108,7 +108,7 @@ import PlayKitProviders
             * callback:
             * error: A `KalturaPlayerError` in case of an issue. See `KalturaPlayerError` for more details.
      */
-    @objc public func loadMedia(options: OVPMediaOptions, callback: @escaping (_ error: Error?) -> Void) {
+    @objc public func loadMedia(options: OVPMediaOptions, callback: @escaping (_ error: NSError?) -> Void) {
         ovpMediaOptions = options
         
         if options.ks?.isEmpty == false {
@@ -128,7 +128,7 @@ import PlayKitProviders
                 if let error = error {
                     switch error {
                     case let pkError as PKError:
-                        callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription))
+                        callback(KalturaPlayerError.mediaProviderError(code: String(pkError.code), message: pkError.errorDescription).asNSError)
                     case let nsError as NSError:
                         var code = String(nsError.code)
                         if let serverErrorCode = nsError.userInfo[ProviderServerErrorCodeKey] as? String, !serverErrorCode.isEmpty {
@@ -138,12 +138,12 @@ import PlayKitProviders
                         if let serverErrorMessage = nsError.userInfo[ProviderServerErrorMessageKey] as? String, !serverErrorMessage.isEmpty {
                             message = serverErrorMessage
                         }
-                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message))
+                        callback(KalturaPlayerError.mediaProviderError(code: code, message: message).asNSError)
                     default:
-                        callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription))
+                        callback(KalturaPlayerError.mediaProviderError(code: "LoadMediaError", message: error.localizedDescription).asNSError)
                     }
                 } else {
-                    callback(KalturaPlayerError.invalidPKMediaEntry)
+                    callback(KalturaPlayerError.invalidPKMediaEntry.asNSError)
                 }
                 
                 return
@@ -151,7 +151,7 @@ import PlayKitProviders
             
             // The Configuration is needed in order to continue.
             guard let ovpPartnerId = KalturaOVPPlayerManager.shared.cachedConfigData?.ovpPartnerId else {
-                callback(KalturaPlayerError.configurationMissing)
+                callback(KalturaPlayerError.configurationMissing.asNSError)
                 return
             }
             


### PR DESCRIPTION
OTT and OVP, checking the error returned in loadMedia first if it is a PKError and then if it's a NSError.
In case it is an NSError fetching the code and message from the userInfo if exists, the code and message will be in the userInfo in case of a server error.
Force a return of an error as NSError in the callback upon loadMedia.
Updated the podspec dependency to the relevant versions.