### PR TITLE
FEC-10758 Added disableMediaHit and disableMediaMark to the OTTMediaO…

### DIFF
--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -110,7 +110,9 @@ import PlayKitKava
         let phoenixAnalyticsPluginConfig = PhoenixAnalyticsPluginConfig(baseUrl: KalturaOTTPlayerManager.shared.serverURL,
                                                                         timerInterval: PhoenixAnalyticsTimerInterval,
                                                                         ks: ks,
-                                                                        partnerId: Int(KalturaOTTPlayerManager.shared.partnerId))
+                                                                        partnerId: Int(KalturaOTTPlayerManager.shared.partnerId),
+                                                                        disableMediaHit: ottMediaOptions?.disableMediaHit ?? false,
+                                                                        disableMediaMark: ottMediaOptions?.disableMediaMark ?? false)
         
         self.updatePluginConfig(pluginName: PhoenixAnalyticsPlugin.pluginName, config: phoenixAnalyticsPluginConfig)
     }

--- a/Sources/OTT/OTTMediaOptions.swift
+++ b/Sources/OTT/OTTMediaOptions.swift
@@ -21,6 +21,9 @@ import PlayKitProviders
     @objc public var urlType: String?
     @objc public var streamerType: String?
     
+    @objc public var disableMediaHit: Bool = false
+    @objc public var disableMediaMark: Bool = false
+    
     internal func mediaProvider() -> PhoenixMediaProvider {
         let phoenixMediaProvider = PhoenixMediaProvider()
         phoenixMediaProvider.set(assetId: assetId)


### PR DESCRIPTION
Solves FEC-10758 
Added disableMediaHit and disableMediaMark to the OTTMediaOptions.

Sending the data upon updating the PhoenixAnalytics plugin upon loading the media.