### PR TITLE
FEC-11688  OfflineManager prepareAsset exposed to ObjC

### DIFF
--- a/Sources/Offline/OTT/OfflineManager+OTT.swift
+++ b/Sources/Offline/OTT/OfflineManager+OTT.swift
@@ -71,7 +71,7 @@ extension OfflineManager {
             * assetInfo: The asset info object, otherwise nil. See `AssetInfo` for more details.
             * mediaEntry: The `PKMediaEntry` retrieved, otherwise nil. See `PKMediaEntry` for more details.
      */
-    public func prepareAsset(mediaOptions: OTTMediaOptions, options: OfflineSelectionOptions, callback: @escaping (_ error: Error?, _ assetInfo: AssetInfo?, _ mediaEntry: PKMediaEntry?) -> Void) {
+    @objc public func prepareAsset(mediaOptions: OTTMediaOptions, options: OfflineSelectionOptions, callback: @escaping (_ error: Error?, _ assetInfo: AssetInfo?, _ mediaEntry: PKMediaEntry?) -> Void) {
         
         retrieveMediaEntry(mediaOptions: mediaOptions) { (error, pkMediaEntry) in
             guard let mediaEntry = pkMediaEntry else {

--- a/Sources/Offline/OfflineManager.swift
+++ b/Sources/Offline/OfflineManager.swift
@@ -20,7 +20,7 @@ import PlayKit
 public typealias OfflineSelectionOptions = DTGSelectionOptions
 
 /// Delegate that will receive download events.
-@objc public protocol OfflineManagerDelegate: class {
+@objc public protocol OfflineManagerDelegate: AnyObject {
     /**
         Some data was downloaded for the item.
      
@@ -182,7 +182,7 @@ public enum OfflineManagerError: PKError {
             * error: An `OfflineManagerError` if an error has occurred, otherwise nil. See `OfflineManagerError` for more details.
             * assetInfo: The asset info object, otherwise nil. See `AssetInfo` for more details.
      */
-    public func prepareAsset(mediaEntry: PKMediaEntry, options: OfflineSelectionOptions, callback: @escaping (_ error: Error?, _ assetInfo: AssetInfo?) -> Void) {
+    @objc public func prepareAsset(mediaEntry: PKMediaEntry, options: OfflineSelectionOptions, callback: @escaping (_ error: Error?, _ assetInfo: AssetInfo?) -> Void) {
         
         let itemId = mediaEntry.id
         guard let mediaSource = localAssetsManager.getPreferredDownloadableMediaSource(for: mediaEntry) else {


### PR DESCRIPTION
FEC-11688

Example how to use in Objective-C:

```ObjC
OTTMediaOptions *options = [[OTTMediaOptions alloc] init];
    DTGSelectionOptions *selection = [[DTGSelectionOptions alloc] init];

    [selection setMinVideoBitrate:1000000 forCodec:TrackCodecAvc1];
    [selection setMinVideoBitrate:2000000 forCodec:TrackCodecMp4a];
    [selection setMinVideoWidth:1280];
    [selection setMinVideoHeight:720];
    [selection setAllTextLanguages:YES];
    [selection setAllAudioLanguages:YES];

    NSArray *codecs = [NSArray arrayWithObjects:
                       [NSNumber numberWithInteger:TrackCodecAvc1],
                       [NSNumber numberWithInteger:TrackCodecHevc], nil];

    [selection setPreferredVideoCodecs:codecs];
    [selection setPreferredAudioCodecs:[NSArray arrayWithObjects:[NSNumber numberWithInteger:TrackCodecAc3], nil]];

    [[OfflineManager shared] prepareAssetWithMediaOptions:options
                                                  options:selection
                                                 callback:^(NSError * _Nullable, AssetInfo * _Nullable, PKMediaEntry * _Nullable) {

    }];
```