### PR TITLE
FEC-11914 Bookmarks are not sent when the ks is set on the media options alone.

### DIFF
--- a/Sources/KalturaPlayer.swift
+++ b/Sources/KalturaPlayer.swift
@@ -100,9 +100,9 @@ public enum KalturaPlayerError: PKError {
                                            callback: @escaping (_ error: NSError?) -> Void) {
         
         if let pluginConfig = pluginConfig {
-            let playerOptions = self.playerOptions
-            playerOptions.pluginConfig = pluginConfig
-            self.updatePlayerOptions(playerOptions)
+            pluginConfig.config.forEach { (name, config) in
+                updatePluginConfig(pluginName: name, config: config)
+            }
         }
         
         self.mediaEntry = mediaEntry
@@ -120,6 +120,7 @@ public enum KalturaPlayerError: PKError {
     @objc public func updatePlayerOptions(_ playerOptions: PlayerOptions) {
         self.playerOptions = playerOptions
         
+        // If the player options was updated, update the player with the new plugin config
         self.playerOptions.pluginConfig.config.forEach { (name, config) in
             pkPlayer.updatePluginConfig(pluginName: name, config: config)
         }

--- a/Sources/KalturaPlayer.swift
+++ b/Sources/KalturaPlayer.swift
@@ -126,6 +126,16 @@ public enum KalturaPlayerError: PKError {
     }
     
     /**
+        Update the player's ks
+     
+        * Parameters:
+            * playerKS: A new player ks.
+     */
+    @objc public func updatePlayerOptionsKS(_ playerKS: String) {
+        self.playerOptions.ks = playerKS
+    }
+    
+    /**
        Set the player's MediaEntry.
     
        * Parameters:

--- a/Sources/OTT/KPOTTPlaylistController.swift
+++ b/Sources/OTT/KPOTTPlaylistController.swift
@@ -13,7 +13,7 @@ import PlayKit
     internal var originalOTTMediaOptions: [OTTMediaOptions]?
     
     override internal func prepareMediaOptions(forMediaEntry entry: PKMediaEntry) -> MediaOptions? {
-        let options: MediaOptions
+        let options: OTTMediaOptions
         
         if let ottOptions = self.originalOTTMediaOptions?.first(where: { $0.assetId == entry.id }) {
             options = ottOptions

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -198,7 +198,7 @@ import PlayKitKava
                 return
             }
             
-            self.setMediaAndUpdatePlugins(mediaEntry: mediaEntry, mediaOptions: options, pluginConfig: self.playerOptions.pluginConfig, callback: callback)
+            self.setMediaAndUpdatePlugins(mediaEntry: mediaEntry, mediaOptions: options, pluginConfig: nil, callback: callback)
         }
     }
     

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -113,19 +113,15 @@ import PlayKitKava
             ovpEntryId = entryId
         }
         
+        // Update KavaPlugin for specific Media
         self.updateKavaPlugin(ovpPartnerId: ovpPartnerId, ovpEntryId: ovpEntryId, mediaOptions: mediaOptions as? OTTMediaOptions)
-        
-        let playerKSNotSet = playerOptions.ks?.isEmpty ?? true
-        let mediaKSAvailable = !(mediaOptions?.ks?.isEmpty ?? true)
-        let shouldUpdatePhoenixAnalytics = playerKSNotSet && mediaKSAvailable
-        if let config = pluginConfig?.config, !config.keys.contains(PhoenixAnalyticsPlugin.pluginName) || shouldUpdatePhoenixAnalytics {
-            self.updatePhoenixAnalyticsPlugin()
-        }
-        
+        // Update PhoenixAnalyticsPlugin for specific Media
+        self.updatePhoenixAnalyticsPlugin()
+        // If any custom plugin config has been sent use it instead.
         if let pluginConfig = pluginConfig {
-            let playerOptions = self.playerOptions
-            playerOptions.pluginConfig = pluginConfig
-            self.updatePlayerOptions(playerOptions)
+            pluginConfig.config.forEach { (name, config) in
+                updatePluginConfig(pluginName: name, config: config)
+            }
         }
         
         self.updateMediaEntryWithLoadedInterceptors(mediaEntry) {

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -68,9 +68,11 @@ import PlayKitKava
                                                 partnerId: KalturaOTTPlayerManager.shared.partnerId,
                                                 ks: options.ks)
         
-        // In case the DMS Configuration won't be available yet, setting the KavaPluginConfig with a placeholder cause an update is performed upon loadMedia without validating if the plugin was set.
-        let partnerId = KalturaOTTPlayerManager.shared.cachedConfigData?.ovpPartnerId ?? KalturaOTTPlayerManager.shared.partnerId
-        options.pluginConfig.config[KavaPlugin.pluginName] = KavaPluginConfig(partnerId: Int(partnerId))
+        if (options.pluginConfig.config[KavaPlugin.pluginName] == nil) {
+            // In case the DMS Configuration won't be available yet, setting the KavaPluginConfig with a placeholder cause an update is performed upon loadMedia without validating if the plugin was set.
+            let partnerId = KalturaOTTPlayerManager.shared.cachedConfigData?.ovpPartnerId ?? KalturaOTTPlayerManager.shared.partnerId
+            options.pluginConfig.config[KavaPlugin.pluginName] = KavaPluginConfig(partnerId: Int(partnerId))
+        }
         
         if (options.pluginConfig.config[PhoenixAnalyticsPlugin.pluginName] == nil) {
             // Have to set the PhoenixAnalyticsPlugin even if the player KS is empty, cause an update is performed upon loadMedia without validating if the plugin was set. The request will not be sent upon an empty KS.

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -196,7 +196,7 @@ import PlayKitKava
                 return
             }
             
-            self.setMediaAndUpdatePlugins(mediaEntry: mediaEntry, mediaOptions: options, pluginConfig: nil, callback: callback)
+            self.setMediaAndUpdatePlugins(mediaEntry: mediaEntry, mediaOptions: options, pluginConfig: self.playerOptions.pluginConfig, callback: callback)
         }
     }
     

--- a/Sources/OTT/KalturaOTTPlayer.swift
+++ b/Sources/OTT/KalturaOTTPlayer.swift
@@ -15,6 +15,11 @@ import PlayKitKava
     private var ottMediaOptions: OTTMediaOptions? {
         didSet {
             mediaOptions = ottMediaOptions
+            
+            // Update player options if we received a ks on the media options
+            if let newKS = mediaOptions?.ks, !newKS.isEmpty {
+                playerOptions.ks = newKS
+            }
         }
     }
     

--- a/Sources/Playlist/KPPlaylistController.swift
+++ b/Sources/Playlist/KPPlaylistController.swift
@@ -307,7 +307,8 @@ import PlayKit
                 }
                 
                 // Update the entry we got back from the provider
-                self.entries[self.currentPlayingIndex] = mediaEntry
+                let currentEntry = self.entries[self.currentPlayingIndex]
+                currentEntry.update(fromMediaEntry: mediaEntry)
                 
                 var pluginConfig: PluginConfig? = nil
                 
@@ -388,7 +389,8 @@ import PlayKit
                 
                 // Update the entry we got back from the provider
                 if let entryIndex = self.entries.firstIndex(of: entry) {
-                    self.entries[entryIndex] = mediaEntry
+                    let entry = self.entries[entryIndex]
+                    entry.update(fromMediaEntry: mediaEntry)
                 }
             }
         }
@@ -470,6 +472,39 @@ import PlayKit
         default:
             PKLog.error("Trying to play next media")
             self.playNext()
+        }
+    }
+}
+
+extension PKMediaEntry {
+    public func update(fromMediaEntry newMediaEntry: PKMediaEntry) {
+        if id != newMediaEntry.id { return }
+        
+        // Update values only if we got new valid values.
+        // We don't want to override values if the new entry doesn't have it.
+        if let newSources = newMediaEntry.sources, !newSources.isEmpty {
+            sources = newSources
+        }
+        if newMediaEntry.duration > 0 {
+            duration = newMediaEntry.duration
+        }
+        if newMediaEntry.mediaType != .unknown {
+            mediaType = newMediaEntry.mediaType
+        }
+        if let newMetadata = newMediaEntry.metadata, !newMetadata.isEmpty {
+            metadata = newMetadata
+        }
+        if let newName = newMediaEntry.name, !newName.isEmpty {
+            name = newName
+        }
+        if let newExternalSubtitles = newMediaEntry.externalSubtitles, !newExternalSubtitles.isEmpty {
+            externalSubtitles = newExternalSubtitles
+        }
+        if let newThumbnailUrl = newMediaEntry.thumbnailUrl, !newThumbnailUrl.isEmpty {
+            thumbnailUrl = newThumbnailUrl
+        }
+        if let newTags = newMediaEntry.tags, !newTags.isEmpty {
+            tags = newTags
         }
     }
 }

--- a/Sources/Playlist/KPPlaylistController.swift
+++ b/Sources/Playlist/KPPlaylistController.swift
@@ -274,7 +274,8 @@ import PlayKit
                 }
             }
             
-            self.player?.setMediaAndUpdatePlugins(mediaEntry: currentEntry, mediaOptions: nil, pluginConfig: pluginConfig, callback: { error in
+            let mediaOptions = self.prepareMediaOptions(forMediaEntry: currentEntry)
+            self.player?.setMediaAndUpdatePlugins(mediaEntry: currentEntry, mediaOptions: mediaOptions, pluginConfig: pluginConfig, callback: { error in
                 self.messageBus?.post(PlaylistEvent.PlaylistCurrentPlayingItemChanged())
             })
         } else {
@@ -319,7 +320,8 @@ import PlayKit
                     }
                 }
                 
-                self.player?.setMediaAndUpdatePlugins(mediaEntry: currentEntry, mediaOptions: nil, pluginConfig: pluginConfig, callback: { error in
+                let mediaOptions = self.prepareMediaOptions(forMediaEntry: mediaEntry)
+                self.player?.setMediaAndUpdatePlugins(mediaEntry: mediaEntry, mediaOptions: mediaOptions, pluginConfig: pluginConfig, callback: { error in
                     self.messageBus?.post(PlaylistEvent.PlaylistCurrentPlayingItemChanged())
                 })
             }


### PR DESCRIPTION
Update to Phoenix Analytics was not performed when the ks was set in the media, therefore bookmarks where not being sent.

Added code to not override Phoenix Analytics config if it was set in the player options upon init.
Added check to not override the kava plugin config in the player options if we received them from the client.

Added KS update to the player options in KalturaPlayer.
Fix in loadPlaylist function to fetch for a first ks occurrence and not only to take the ks from the first media option.

Fixed logic to update Kava and Phoenix plugin for specific media then if any custom plugin was sent update the specific config and not to override all configs.

Need to send the current mediaOptions in playlist for the plugins.

Updated logic in Playlist to save the whole media entry retrieved and not just it's sources, the metaData is needed as well.

Solves FEC-11914
Solves FEC-11913
Solves FEC-10249