### PR TITLE
FEC-11967 Fixed logic which was always true.

### DIFF
--- a/Sources/KalturaPlayer.swift
+++ b/Sources/KalturaPlayer.swift
@@ -176,7 +176,7 @@ public enum KalturaPlayerError: PKError {
         shouldPrepare = false
         // Create media config
         let mediaConfig: MediaConfig
-        if let startTime = mediaOptions?.startTime, startTime != TimeInterval.nan {
+        if let startTime = mediaOptions?.startTime, !startTime.isNaN {
             mediaConfig = MediaConfig(mediaEntry: mediaEntry, startTime: startTime)
         } else {
             mediaConfig = MediaConfig(mediaEntry: mediaEntry)


### PR DESCRIPTION
Fixed logic which was always true causing the startTime to be sent even if it was not configured (set as NaN).

Solves FEC-11967