### PR TITLE
FEC-12124 Add Youtube referenceId Support

### DIFF
--- a/Sources/KalturaPlayer.swift
+++ b/Sources/KalturaPlayer.swift
@@ -209,7 +209,7 @@ public enum KalturaPlayerError: PKError {
 
         Upon setting to a new value, if the PlayerOption autoPlay or preload is set too true, prepare on the player will be automatically called.
      */
-    public var mediaEntry: PKMediaEntry? {
+    internal var mediaEntry: PKMediaEntry? {
         didSet {
             if mediaEntry == nil { return }
             shouldPrepare = true
@@ -217,6 +217,10 @@ public enum KalturaPlayerError: PKError {
                 prepare()
             }
         }
+    }
+    
+    @objc public var currentMediaEntryMetadata: [String: String]? {
+        return mediaEntry?.metadata
     }
     
     /// The player's settings.

--- a/Sources/KalturaPlayer.swift
+++ b/Sources/KalturaPlayer.swift
@@ -209,7 +209,7 @@ public enum KalturaPlayerError: PKError {
 
         Upon setting to a new value, if the PlayerOption autoPlay or preload is set too true, prepare on the player will be automatically called.
      */
-    internal var mediaEntry: PKMediaEntry? {
+    public var mediaEntry: PKMediaEntry? {
         didSet {
             if mediaEntry == nil { return }
             shouldPrepare = true


### PR DESCRIPTION
Solves FEC-12124
Add Youtube referenceId Support

Example of `externalSourceType` handling

```Swift
kalturaOVPPlayer.loadMedia(options: mediaOptions) { [weak self] (error) in
                    guard let self = self else { return }
                    if let error = error {
                        let message = error.localizedDescription

                        let alert = UIAlertController(title: "Media not loaded", message: message, preferredStyle: UIAlertController.Style.alert)
                        alert.addAction(UIAlertAction(title: "Ok", style: .cancel, handler: { (alert) in
                            self.dismiss(animated: true, completion: nil)
                        }))
                        self.present(alert, animated: true, completion: nil)
                    } else {
                        
                        if let externalSourceType = self.kalturaOVPPlayer.currentMediaEntryMetadata?["externalSourceType"],
                           externalSourceType == "YouTube" {
                            print("YouTube is Playing: \(self.kalturaOVPPlayer.currentMediaEntryMetadata?["referenceId"])")
                        } else {
                            // If the autoPlay and preload was set to false, prepare will not be called automatically
                            if videoData.player.autoPlay == false && videoData.player.preload == false {
                                self.kalturaOVPPlayer.prepare()
                            }
                        }
                    }
                }
```