### PR TITLE
FEC-12418 Xcode 14 fixes

### DIFF
--- a/.github/cocoapods_publish.sh
+++ b/.github/cocoapods_publish.sh
@@ -10,4 +10,4 @@ EOF
 
 chmod 0600 ~/.netrc
 
-pod trunk push --verbose
+pod trunk push --verbose --allow-warnings

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -28,4 +28,4 @@ jobs:
       run: pod repo update
 
     - name: Pod linting
-      run: pod lib lint --fail-fast --verbose
+      run: pod lib lint --fail-fast --verbose --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CocoaPods Release
+name: Release
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Solves FEC-12418
- Actions workflows --allow-warnings added to silence DEPLOYMENT_TARGET warnings during pod lint.